### PR TITLE
george / rm64676 / Enable only the required tabs/routes on the cashier page for CRA accounts

### DIFF
--- a/packages/cashier/src/constants/routes-config.js
+++ b/packages/cashier/src/constants/routes-config.js
@@ -8,103 +8,89 @@ import { AccountTransfer, Deposit, OnRamp, P2PCashier, PaymentAgent, PaymentAgen
 const Page404 = React.lazy(() => moduleLoader(() => import(/* webpackChunkName: "404" */ 'Components/page-404')));
 
 // Order matters
-const initRoutesConfig = is_cra => {
-    const cashier_module = [
-        {
-            path: routes.cashier,
-            component: Cashier,
-            is_modal: true,
-            is_authenticated: true,
-            getTitle: () => localize('Cashier'),
-            icon_component: 'IcCashier',
-            routes: [
-                {
-                    path: routes.cashier_deposit,
-                    component: Deposit,
-                    getTitle: () => localize('Deposit'),
-                    icon_component: 'IcCashierAdd',
-                    is_visible_for: [],
-                    default: true,
-                },
-                {
-                    path: routes.cashier_withdrawal,
-                    component: Withdrawal,
-                    getTitle: () => localize('Withdrawal'),
-                    icon_component: 'IcCashierMinus',
-                    is_visible_for: ['affiliate'],
-                },
-                {
-                    path: routes.cashier_pa,
-                    component: PaymentAgent,
-                    getTitle: () => localize('Payment agents'),
-                    icon_component: 'IcPaymentAgent',
-                    is_visible_for: [],
-                },
-                {
-                    path: routes.cashier_acc_transfer,
-                    component: AccountTransfer,
-                    getTitle: () => localize('Transfer'),
-                    icon_component: 'IcAccountTransfer',
-                    is_visible_for: ['affiliate'],
-                },
-                {
-                    path: routes.cashier_pa_transfer,
-                    component: PaymentAgentTransfer,
-                    getTitle: () => localize('Transfer to client'),
-                    icon_component: 'IcAccountTransfer',
-                    is_visible_for: [],
-                },
-                {
-                    path: routes.cashier_p2p,
-                    component: P2PCashier,
-                    getTitle: () => localize('Deriv P2P'),
-                    icon_component: 'IcDp2p',
-                    is_visible_for: [],
-                },
-                {
-                    path: routes.cashier_p2p_verification,
-                    component: P2PCashier,
-                    getTitle: () => localize('Deriv P2P'),
-                    icon_component: 'IcDp2p',
-                    is_invisible: true,
-                    is_visible_for: [],
-                },
-                {
-                    id: 'gtm-onramp-tab',
-                    path: routes.cashier_onramp,
-                    component: OnRamp,
-                    getTitle: () => localize('Fiat onramp'),
-                    icon_component: 'IcCashierOnRamp',
-                    is_visible_for: [],
-                },
-            ],
-        },
-    ];
+const initRoutesConfig = () => [
+    {
+        path: routes.cashier,
+        component: Cashier,
+        is_modal: true,
+        is_authenticated: true,
+        getTitle: () => localize('Cashier'),
+        icon_component: 'IcCashier',
+        routes: [
+            {
+                path: routes.cashier_deposit,
+                component: Deposit,
+                getTitle: () => localize('Deposit'),
+                icon_component: 'IcCashierAdd',
+                hide_for: ['affiliate'],
+                default: true,
+            },
+            {
+                path: routes.cashier_withdrawal,
+                component: Withdrawal,
+                getTitle: () => localize('Withdrawal'),
+                icon_component: 'IcCashierMinus',
+                hide_for: [],
+            },
+            {
+                path: routes.cashier_pa,
+                component: PaymentAgent,
+                getTitle: () => localize('Payment agents'),
+                icon_component: 'IcPaymentAgent',
+                hide_for: ['affiliate'],
+            },
+            {
+                path: routes.cashier_acc_transfer,
+                component: AccountTransfer,
+                getTitle: () => localize('Transfer'),
+                icon_component: 'IcAccountTransfer',
+                hide_for: [],
+            },
+            {
+                path: routes.cashier_pa_transfer,
+                component: PaymentAgentTransfer,
+                getTitle: () => localize('Transfer to client'),
+                icon_component: 'IcAccountTransfer',
+                hide_for: ['affiliate'],
+            },
+            {
+                path: routes.cashier_p2p,
+                component: P2PCashier,
+                getTitle: () => localize('Deriv P2P'),
+                icon_component: 'IcDp2p',
+                hide_for: ['affiliate'],
+            },
+            {
+                path: routes.cashier_p2p_verification,
+                component: P2PCashier,
+                getTitle: () => localize('Deriv P2P'),
+                icon_component: 'IcDp2p',
+                is_invisible: true,
+                hide_for: ['affiliate'],
+            },
+            {
+                id: 'gtm-onramp-tab',
+                path: routes.cashier_onramp,
+                component: OnRamp,
+                getTitle: () => localize('Fiat onramp'),
+                icon_component: 'IcCashierOnRamp',
+                hide_for: ['affiliate'],
+            },
+        ],
+    },
+];
 
-    if (is_cra) {
-        cashier_module.forEach(cashier => {
-            if (cashier.routes) {
-                cashier.routes = cashier.routes.filter(route => route.is_visible_for.includes('affiliate'));
-            }
-        });
-    }
+let routesConfig;
 
-    return cashier_module;
-};
-
-let routes_config, cra_routes_config;
 // For default page route if page/path is not found, must be kept at the end of routes_config array
 const route_default = { component: Page404, getTitle: () => localize('Error 404') };
 
-const getRoutesConfig = is_cra => {
-    if (is_cra && !cra_routes_config) {
-        cra_routes_config = initRoutesConfig(true);
-        cra_routes_config.push(route_default);
-    } else if (!routes_config) {
-        routes_config = initRoutesConfig(false);
-        routes_config.push(route_default);
+const getRoutesConfig = () => {
+    if (!routesConfig) {
+        routesConfig = initRoutesConfig();
+        routesConfig.push(route_default);
     }
-    return is_cra ? cra_routes_config : routes_config;
+    return routesConfig;
 };
 
 export default getRoutesConfig;

--- a/packages/cashier/src/constants/routes-config.js
+++ b/packages/cashier/src/constants/routes-config.js
@@ -8,81 +8,103 @@ import { AccountTransfer, Deposit, OnRamp, P2PCashier, PaymentAgent, PaymentAgen
 const Page404 = React.lazy(() => moduleLoader(() => import(/* webpackChunkName: "404" */ 'Components/page-404')));
 
 // Order matters
-const initRoutesConfig = () => [
-    {
-        path: routes.cashier,
-        component: Cashier,
-        is_modal: true,
-        is_authenticated: true,
-        getTitle: () => localize('Cashier'),
-        icon_component: 'IcCashier',
-        routes: [
-            {
-                path: routes.cashier_deposit,
-                component: Deposit,
-                getTitle: () => localize('Deposit'),
-                icon_component: 'IcCashierAdd',
-                default: true,
-            },
-            {
-                path: routes.cashier_withdrawal,
-                component: Withdrawal,
-                getTitle: () => localize('Withdrawal'),
-                icon_component: 'IcCashierMinus',
-            },
-            {
-                path: routes.cashier_pa,
-                component: PaymentAgent,
-                getTitle: () => localize('Payment agents'),
-                icon_component: 'IcPaymentAgent',
-            },
-            {
-                path: routes.cashier_acc_transfer,
-                component: AccountTransfer,
-                getTitle: () => localize('Transfer'),
-                icon_component: 'IcAccountTransfer',
-            },
-            {
-                path: routes.cashier_pa_transfer,
-                component: PaymentAgentTransfer,
-                getTitle: () => localize('Transfer to client'),
-                icon_component: 'IcAccountTransfer',
-            },
-            {
-                path: routes.cashier_p2p,
-                component: P2PCashier,
-                getTitle: () => localize('Deriv P2P'),
-                icon_component: 'IcDp2p',
-            },
-            {
-                path: routes.cashier_p2p_verification,
-                component: P2PCashier,
-                getTitle: () => localize('Deriv P2P'),
-                icon_component: 'IcDp2p',
-                is_invisible: true,
-            },
-            {
-                id: 'gtm-onramp-tab',
-                path: routes.cashier_onramp,
-                component: OnRamp,
-                getTitle: () => localize('Fiat onramp'),
-                icon_component: 'IcCashierOnRamp',
-            },
-        ],
-    },
-];
+const initRoutesConfig = is_cra => {
+    const cashier_module = [
+        {
+            path: routes.cashier,
+            component: Cashier,
+            is_modal: true,
+            is_authenticated: true,
+            getTitle: () => localize('Cashier'),
+            icon_component: 'IcCashier',
+            routes: [
+                {
+                    path: routes.cashier_deposit,
+                    component: Deposit,
+                    getTitle: () => localize('Deposit'),
+                    icon_component: 'IcCashierAdd',
+                    is_affiliate: false,
+                    default: true,
+                },
+                {
+                    path: routes.cashier_withdrawal,
+                    component: Withdrawal,
+                    getTitle: () => localize('Withdrawal'),
+                    icon_component: 'IcCashierMinus',
+                    is_affiliate: true,
+                },
+                {
+                    path: routes.cashier_pa,
+                    component: PaymentAgent,
+                    getTitle: () => localize('Payment agents'),
+                    icon_component: 'IcPaymentAgent',
+                    is_affiliate: false,
+                },
+                {
+                    path: routes.cashier_acc_transfer,
+                    component: AccountTransfer,
+                    getTitle: () => localize('Transfer'),
+                    icon_component: 'IcAccountTransfer',
+                    is_affiliate: true,
+                },
+                {
+                    path: routes.cashier_pa_transfer,
+                    component: PaymentAgentTransfer,
+                    getTitle: () => localize('Transfer to client'),
+                    icon_component: 'IcAccountTransfer',
+                    is_affiliate: false,
+                },
+                {
+                    path: routes.cashier_p2p,
+                    component: P2PCashier,
+                    getTitle: () => localize('Deriv P2P'),
+                    icon_component: 'IcDp2p',
+                    is_affiliate: false,
+                },
+                {
+                    path: routes.cashier_p2p_verification,
+                    component: P2PCashier,
+                    getTitle: () => localize('Deriv P2P'),
+                    icon_component: 'IcDp2p',
+                    is_invisible: true,
+                    is_affiliate: false,
+                },
+                {
+                    id: 'gtm-onramp-tab',
+                    path: routes.cashier_onramp,
+                    component: OnRamp,
+                    getTitle: () => localize('Fiat onramp'),
+                    icon_component: 'IcCashierOnRamp',
+                    is_affiliate: false,
+                },
+            ],
+        },
+    ];
 
-let routesConfig;
+    if (is_cra) {
+        cashier_module.forEach(cashier => {
+            if (cashier.routes) {
+                cashier.routes = cashier.routes.filter(route => route.is_affiliate);
+            }
+        });
+    }
 
+    return cashier_module;
+};
+
+let routes_config, cra_routes_config;
 // For default page route if page/path is not found, must be kept at the end of routes_config array
 const route_default = { component: Page404, getTitle: () => localize('Error 404') };
 
-const getRoutesConfig = ({ is_appstore }) => {
-    if (!routesConfig) {
-        routesConfig = initRoutesConfig({ is_appstore });
-        routesConfig.push(route_default);
+const getRoutesConfig = is_cra => {
+    if (!routes_config && !cra_routes_config) {
+        routes_config = initRoutesConfig(false);
+        routes_config.push(route_default);
+        cra_routes_config = initRoutesConfig(true);
+        cra_routes_config.push(route_default);
     }
-    return routesConfig;
+
+    return is_cra ? cra_routes_config : routes_config;
 };
 
 export default getRoutesConfig;

--- a/packages/cashier/src/constants/routes-config.js
+++ b/packages/cashier/src/constants/routes-config.js
@@ -23,7 +23,7 @@ const initRoutesConfig = is_cra => {
                     component: Deposit,
                     getTitle: () => localize('Deposit'),
                     icon_component: 'IcCashierAdd',
-                    is_affiliate: false,
+                    is_visible_for: [],
                     default: true,
                 },
                 {
@@ -31,35 +31,35 @@ const initRoutesConfig = is_cra => {
                     component: Withdrawal,
                     getTitle: () => localize('Withdrawal'),
                     icon_component: 'IcCashierMinus',
-                    is_affiliate: true,
+                    is_visible_for: ['affiliate'],
                 },
                 {
                     path: routes.cashier_pa,
                     component: PaymentAgent,
                     getTitle: () => localize('Payment agents'),
                     icon_component: 'IcPaymentAgent',
-                    is_affiliate: false,
+                    is_visible_for: [],
                 },
                 {
                     path: routes.cashier_acc_transfer,
                     component: AccountTransfer,
                     getTitle: () => localize('Transfer'),
                     icon_component: 'IcAccountTransfer',
-                    is_affiliate: true,
+                    is_visible_for: ['affiliate'],
                 },
                 {
                     path: routes.cashier_pa_transfer,
                     component: PaymentAgentTransfer,
                     getTitle: () => localize('Transfer to client'),
                     icon_component: 'IcAccountTransfer',
-                    is_affiliate: false,
+                    is_visible_for: [],
                 },
                 {
                     path: routes.cashier_p2p,
                     component: P2PCashier,
                     getTitle: () => localize('Deriv P2P'),
                     icon_component: 'IcDp2p',
-                    is_affiliate: false,
+                    is_visible_for: [],
                 },
                 {
                     path: routes.cashier_p2p_verification,
@@ -67,7 +67,7 @@ const initRoutesConfig = is_cra => {
                     getTitle: () => localize('Deriv P2P'),
                     icon_component: 'IcDp2p',
                     is_invisible: true,
-                    is_affiliate: false,
+                    is_visible_for: [],
                 },
                 {
                     id: 'gtm-onramp-tab',
@@ -75,7 +75,7 @@ const initRoutesConfig = is_cra => {
                     component: OnRamp,
                     getTitle: () => localize('Fiat onramp'),
                     icon_component: 'IcCashierOnRamp',
-                    is_affiliate: false,
+                    is_visible_for: [],
                 },
             ],
         },
@@ -84,7 +84,7 @@ const initRoutesConfig = is_cra => {
     if (is_cra) {
         cashier_module.forEach(cashier => {
             if (cashier.routes) {
-                cashier.routes = cashier.routes.filter(route => route.is_affiliate);
+                cashier.routes = cashier.routes.filter(route => route.is_visible_for.includes('affiliate'));
             }
         });
     }
@@ -103,7 +103,6 @@ const getRoutesConfig = is_cra => {
         cra_routes_config = initRoutesConfig(true);
         cra_routes_config.push(route_default);
     }
-
     return is_cra ? cra_routes_config : routes_config;
 };
 

--- a/packages/cashier/src/constants/routes-config.js
+++ b/packages/cashier/src/constants/routes-config.js
@@ -97,11 +97,12 @@ let routes_config, cra_routes_config;
 const route_default = { component: Page404, getTitle: () => localize('Error 404') };
 
 const getRoutesConfig = is_cra => {
-    if (!routes_config && !cra_routes_config) {
-        routes_config = initRoutesConfig(false);
-        routes_config.push(route_default);
+    if (is_cra && !cra_routes_config) {
         cra_routes_config = initRoutesConfig(true);
         cra_routes_config.push(route_default);
+    } else if (!routes_config) {
+        routes_config = initRoutesConfig(false);
+        routes_config.push(route_default);
     }
     return is_cra ? cra_routes_config : routes_config;
 };

--- a/packages/cashier/src/containers/cashier/__tests__/cashier.spec.js
+++ b/packages/cashier/src/containers/cashier/__tests__/cashier.spec.js
@@ -58,7 +58,7 @@ describe('<Cashier />', () => {
         is_p2p_enabled: true,
         is_onramp_tab_visible: true,
         is_visible: true,
-        routes: getRoutesConfig({})[0].routes,
+        routes: getRoutesConfig()[0].routes,
         routeBackInApp: jest.fn(),
         onMount: jest.fn(),
         setAccountSwitchListener: jest.fn(),

--- a/packages/cashier/src/containers/cashier/cashier.jsx
+++ b/packages/cashier/src/containers/cashier/cashier.jsx
@@ -23,6 +23,7 @@ const Cashier = ({
     is_account_transfer_visible,
     is_account_setting_loaded,
     is_cashier_onboarding,
+    is_cra,
     is_crypto,
     is_crypto_transactions_visible,
     is_loading,
@@ -66,7 +67,18 @@ const Cashier = ({
     const getMenuOptions = () => {
         const options = [];
         routes_config.forEach(route => {
-            if (
+            if (is_cra) {
+                if (!route.hide_for.includes('affiliate')) {
+                    options.push({
+                        default: route.default,
+                        icon: route.icon_component,
+                        label: route.getTitle(),
+                        value: route.component,
+                        path: route.path,
+                        has_side_note: is_crypto_transactions_visible ? false : route.path !== routes.cashier_p2p, // Set to true to create the 3-column effect without passing any content. If there is content, the content should be passed in.
+                    });
+                }
+            } else if (
                 !route.is_invisible &&
                 (route.path !== routes.cashier_pa || is_payment_agent_visible) &&
                 (route.path !== routes.cashier_pa_transfer || is_payment_agent_transfer_visible) &&
@@ -184,6 +196,7 @@ Cashier.propTypes = {
     is_account_transfer_visible: PropTypes.bool,
     is_account_setting_loaded: PropTypes.bool,
     is_cashier_onboarding: PropTypes.bool,
+    is_cra: PropTypes.bool,
     is_crypto: PropTypes.bool,
     is_crypto_transactions_visible: PropTypes.bool,
     is_loading: PropTypes.bool,
@@ -212,6 +225,7 @@ export default connect(({ client, common, modules, ui }) => ({
     is_cashier_onboarding: modules.cashier.general_store.is_cashier_onboarding,
     is_account_transfer_visible: modules.cashier.account_transfer.is_account_transfer_visible,
     is_account_setting_loaded: client.is_account_setting_loaded,
+    is_cra: client.is_cra,
     is_crypto: modules.cashier.general_store.is_crypto,
     is_crypto_transactions_visible: modules.cashier.transaction_history.is_crypto_transactions_visible,
     is_loading: modules.cashier.general_store.is_loading,

--- a/packages/cashier/src/containers/cashier/cashier.jsx
+++ b/packages/cashier/src/containers/cashier/cashier.jsx
@@ -66,7 +66,6 @@ const Cashier = ({
     const onClickClose = () => routeBackInApp(history);
     const getMenuOptions = () => {
         const options = [];
-
         routes_config.forEach(route => {
             if (
                 (is_cra && !route.hide_for.includes('affiliate')) ||

--- a/packages/cashier/src/containers/cashier/cashier.jsx
+++ b/packages/cashier/src/containers/cashier/cashier.jsx
@@ -64,19 +64,22 @@ const Cashier = ({
     }, [is_logged_in, onMount, setAccountSwitchListener]);
 
     const onClickClose = () => routeBackInApp(history);
+
+    const is_cra_route_visible = route => is_cra && !route.hide_for.includes('affiliate');
+
+    const is_non_cra_route_visible = route =>
+        !is_cra &&
+        !route.is_invisible &&
+        (route.path !== routes.cashier_pa || is_payment_agent_visible) &&
+        (route.path !== routes.cashier_pa_transfer || is_payment_agent_transfer_visible) &&
+        (route.path !== routes.cashier_p2p || is_p2p_enabled) &&
+        (route.path !== routes.cashier_onramp || is_onramp_tab_visible) &&
+        (route.path !== routes.cashier_acc_transfer || is_account_transfer_visible);
+
     const getMenuOptions = () => {
         const options = [];
         routes_config.forEach(route => {
-            if (
-                (is_cra && !route.hide_for.includes('affiliate')) ||
-                (!is_cra &&
-                    !route.is_invisible &&
-                    (route.path !== routes.cashier_pa || is_payment_agent_visible) &&
-                    (route.path !== routes.cashier_pa_transfer || is_payment_agent_transfer_visible) &&
-                    (route.path !== routes.cashier_p2p || is_p2p_enabled) &&
-                    (route.path !== routes.cashier_onramp || is_onramp_tab_visible) &&
-                    (route.path !== routes.cashier_acc_transfer || is_account_transfer_visible))
-            ) {
+            if (is_cra_route_visible(route) || is_non_cra_route_visible(route)) {
                 options.push({
                     ...(route.path === routes.cashier_p2p && { count: p2p_notification_count }),
                     default: route.default,

--- a/packages/cashier/src/containers/cashier/cashier.jsx
+++ b/packages/cashier/src/containers/cashier/cashier.jsx
@@ -66,25 +66,17 @@ const Cashier = ({
     const onClickClose = () => routeBackInApp(history);
     const getMenuOptions = () => {
         const options = [];
+
         routes_config.forEach(route => {
-            if (is_cra) {
-                if (!route.hide_for.includes('affiliate')) {
-                    options.push({
-                        default: route.default,
-                        icon: route.icon_component,
-                        label: route.getTitle(),
-                        value: route.component,
-                        path: route.path,
-                        has_side_note: is_crypto_transactions_visible ? false : route.path !== routes.cashier_p2p, // Set to true to create the 3-column effect without passing any content. If there is content, the content should be passed in.
-                    });
-                }
-            } else if (
-                !route.is_invisible &&
-                (route.path !== routes.cashier_pa || is_payment_agent_visible) &&
-                (route.path !== routes.cashier_pa_transfer || is_payment_agent_transfer_visible) &&
-                (route.path !== routes.cashier_p2p || is_p2p_enabled) &&
-                (route.path !== routes.cashier_onramp || is_onramp_tab_visible) &&
-                (route.path !== routes.cashier_acc_transfer || is_account_transfer_visible)
+            if (
+                (is_cra && !route.hide_for.includes('affiliate')) ||
+                (!is_cra &&
+                    !route.is_invisible &&
+                    (route.path !== routes.cashier_pa || is_payment_agent_visible) &&
+                    (route.path !== routes.cashier_pa_transfer || is_payment_agent_transfer_visible) &&
+                    (route.path !== routes.cashier_p2p || is_p2p_enabled) &&
+                    (route.path !== routes.cashier_onramp || is_onramp_tab_visible) &&
+                    (route.path !== routes.cashier_acc_transfer || is_account_transfer_visible))
             ) {
                 options.push({
                     ...(route.path === routes.cashier_p2p && { count: p2p_notification_count }),

--- a/packages/cashier/src/containers/routes/binary-routes.jsx
+++ b/packages/cashier/src/containers/routes/binary-routes.jsx
@@ -5,8 +5,6 @@ import getRoutesConfig from 'Constants/routes-config';
 import RouteWithSubRoutes from './route-with-sub-routes.jsx';
 
 const BinaryRoutes = props => {
-    const { is_cra } = props;
-
     return (
         <React.Suspense
             fallback={() => {
@@ -18,7 +16,7 @@ const BinaryRoutes = props => {
             }}
         >
             <Switch>
-                {getRoutesConfig(is_cra).map((route, idx) => (
+                {getRoutesConfig().map((route, idx) => (
                     <RouteWithSubRoutes key={idx} {...route} {...props} />
                 ))}
             </Switch>

--- a/packages/cashier/src/containers/routes/binary-routes.jsx
+++ b/packages/cashier/src/containers/routes/binary-routes.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Switch } from 'react-router-dom';
-import { Localize, PlatformContext } from '@deriv/shared';
+import { Localize } from '@deriv/shared';
 import getRoutesConfig from 'Constants/routes-config';
 import RouteWithSubRoutes from './route-with-sub-routes.jsx';
 
 const BinaryRoutes = props => {
-    const { is_appstore } = React.useContext(PlatformContext);
+    const { is_cra } = props;
 
     return (
         <React.Suspense
@@ -18,7 +18,7 @@ const BinaryRoutes = props => {
             }}
         >
             <Switch>
-                {getRoutesConfig({ is_appstore }).map((route, idx) => (
+                {getRoutesConfig(is_cra).map((route, idx) => (
                     <RouteWithSubRoutes key={idx} {...route} {...props} />
                 ))}
             </Switch>

--- a/packages/cashier/src/containers/routes/route-with-sub-routes.jsx
+++ b/packages/cashier/src/containers/routes/route-with-sub-routes.jsx
@@ -12,6 +12,14 @@ import {
 import { getLanguage } from '@deriv/translations';
 
 const RouteWithSubRoutes = route => {
+    const { is_cra } = route;
+
+    const validateCraRoutes = pathname => {
+        return [routes.cashier_withdrawal, routes.cashier_acc_transfer].includes(pathname);
+    };
+
+    const is_valid_cra_route = validateCraRoutes(location.pathname);
+
     const renderFactory = props => {
         let result = null;
         if (route.component === Redirect) {
@@ -25,6 +33,8 @@ const RouteWithSubRoutes = route => {
             result = <Redirect to={to} />;
         } else if (route.is_authenticated && !route.is_logging_in && !route.is_logged_in) {
             redirectToLogin(route.is_logged_in, getLanguage());
+        } else if (is_cra && !is_valid_cra_route) {
+            result = <Redirect to={routes.cashier_withdrawal} />;
         } else {
             const default_subroute = route.routes ? route.routes.find(r => r.default) : {};
             const has_default_subroute = !isEmptyObject(default_subroute);

--- a/packages/cashier/src/containers/routes/routes.jsx
+++ b/packages/cashier/src/containers/routes/routes.jsx
@@ -6,25 +6,17 @@ import { connect } from 'Stores/connect';
 import BinaryRoutes from './binary-routes.jsx';
 import ErrorComponent from './error-component';
 
-const Routes = ({ error, has_error, is_cra, is_logged_in, is_logging_in, passthrough }) => {
+const Routes = ({ error, has_error, is_logged_in, is_logging_in, passthrough }) => {
     if (has_error) {
         return <ErrorComponent {...error} />;
     }
 
-    return (
-        <BinaryRoutes
-            is_cra={is_cra}
-            is_logged_in={is_logged_in}
-            is_logging_in={is_logging_in}
-            passthrough={passthrough}
-        />
-    );
+    return <BinaryRoutes is_logged_in={is_logged_in} is_logging_in={is_logging_in} passthrough={passthrough} />;
 };
 
 Routes.propTypes = {
     error: MobxPropTypes.objectOrObservableObject,
     has_error: PropTypes.bool,
-    is_cra: PropTypes.bool,
     is_logged_in: PropTypes.bool,
     is_logging_in: PropTypes.bool,
     is_virtual: PropTypes.bool,
@@ -37,7 +29,6 @@ export default withRouter(
     connect(({ client, common }) => ({
         error: common.error,
         has_error: common.has_error,
-        is_cra: client.is_cra,
         is_logged_in: client.is_logged_in,
         is_logging_in: client.is_logging_in,
     }))(Routes)

--- a/packages/cashier/src/containers/routes/routes.jsx
+++ b/packages/cashier/src/containers/routes/routes.jsx
@@ -6,17 +6,25 @@ import { connect } from 'Stores/connect';
 import BinaryRoutes from './binary-routes.jsx';
 import ErrorComponent from './error-component';
 
-const Routes = ({ error, has_error, is_logged_in, is_logging_in, passthrough }) => {
+const Routes = ({ error, has_error, is_cra, is_logged_in, is_logging_in, passthrough }) => {
     if (has_error) {
         return <ErrorComponent {...error} />;
     }
 
-    return <BinaryRoutes is_logged_in={is_logged_in} is_logging_in={is_logging_in} passthrough={passthrough} />;
+    return (
+        <BinaryRoutes
+            is_cra={is_cra}
+            is_logged_in={is_logged_in}
+            is_logging_in={is_logging_in}
+            passthrough={passthrough}
+        />
+    );
 };
 
 Routes.propTypes = {
     error: MobxPropTypes.objectOrObservableObject,
     has_error: PropTypes.bool,
+    is_cra: PropTypes.bool,
     is_logged_in: PropTypes.bool,
     is_logging_in: PropTypes.bool,
     is_virtual: PropTypes.bool,
@@ -27,9 +35,10 @@ Routes.propTypes = {
 // to prevent updates on <BinaryRoutes /> from being blocked
 export default withRouter(
     connect(({ client, common }) => ({
-        is_logged_in: client.is_logged_in,
-        is_logging_in: client.is_logging_in,
         error: common.error,
         has_error: common.has_error,
+        is_cra: client.is_cra,
+        is_logged_in: client.is_logged_in,
+        is_logging_in: client.is_logging_in,
     }))(Routes)
 );

--- a/packages/cashier/src/containers/routes/routes.jsx
+++ b/packages/cashier/src/containers/routes/routes.jsx
@@ -6,17 +6,25 @@ import { connect } from 'Stores/connect';
 import BinaryRoutes from './binary-routes.jsx';
 import ErrorComponent from './error-component';
 
-const Routes = ({ error, has_error, is_logged_in, is_logging_in, passthrough }) => {
+const Routes = ({ error, is_cra, has_error, is_logged_in, is_logging_in, passthrough }) => {
     if (has_error) {
         return <ErrorComponent {...error} />;
     }
 
-    return <BinaryRoutes is_logged_in={is_logged_in} is_logging_in={is_logging_in} passthrough={passthrough} />;
+    return (
+        <BinaryRoutes
+            is_cra={is_cra}
+            is_logged_in={is_logged_in}
+            is_logging_in={is_logging_in}
+            passthrough={passthrough}
+        />
+    );
 };
 
 Routes.propTypes = {
     error: MobxPropTypes.objectOrObservableObject,
     has_error: PropTypes.bool,
+    is_cra: PropTypes.bool,
     is_logged_in: PropTypes.bool,
     is_logging_in: PropTypes.bool,
     is_virtual: PropTypes.bool,
@@ -29,6 +37,7 @@ export default withRouter(
     connect(({ client, common }) => ({
         error: common.error,
         has_error: common.has_error,
+        is_cra: client.is_cra,
         is_logged_in: client.is_logged_in,
         is_logging_in: client.is_logging_in,
     }))(Routes)

--- a/packages/reports/jest.config.js
+++ b/packages/reports/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
         '^_common/(.*)$': '<rootDir>/src/_common/$1',
         '^App/(.*)$': '<rootDir>/src/App/$1',
         '^Assets/(.*)$': '<rootDir>/src/Assets/$1',
+        '^Components/(.*)$': '<rootDir>/src/Components/$1',
         '^Constants/(.*)$': '<rootDir>/src/Constants/$1',
         '^Constants$': '<rootDir>/src/Constants/index.js',
         '^Documents/(.*)$': '<rootDir>/src/Documents/$1',


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   in this PR we:

1.  enable only `Withdrawal` and `Transfer` tabs for CRA accounts; 
2. redirect CRA accounts to `Withdrawal` tab, if the user will type direct URL address (e.g app.deriv.com/cahier/deposit) which is not supported for CRA accounts;

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
